### PR TITLE
hash_item: Fix key_size on big endian systems

### DIFF
--- a/gvdb/src/read/hash_item.rs
+++ b/gvdb/src/read/hash_item.rs
@@ -76,7 +76,7 @@ impl GvdbHashItem {
         value: GvdbPointer,
     ) -> Self {
         let key_start = key_ptr.start().to_le();
-        let key_size = key_ptr.size().to_le() as u16;
+        let key_size = (key_ptr.size() as u16).to_le();
 
         let typ = typ.try_into().unwrap_or(b'v');
 


### PR DESCRIPTION
key_size would get truncated because the conversion to little endian would happen before the cast to u16.

Closes #13 