### PR TITLE
code: Fix zerocopy derive use

### DIFF
--- a/gvdb/Cargo.toml
+++ b/gvdb/Cargo.toml
@@ -15,8 +15,7 @@ categories.workspace = true
 all-features = true
 
 [dependencies]
-zerocopy = "0.7"
-zerocopy-derive = "0.7"
+zerocopy = { version = "0.7", features = ["derive"] }
 serde = { version = "1.0", features = ["derive"] }
 zvariant = { version = "4.0", default-features = false, features = [
     "gvariant",

--- a/gvdb/src/read/hash.rs
+++ b/gvdb/src/read/hash.rs
@@ -5,8 +5,7 @@ use serde::Deserialize;
 use std::fmt::{Debug, Formatter};
 use std::mem::size_of;
 use zerocopy::byteorder::little_endian::U32 as u32le;
-use zerocopy::{AsBytes, FromBytes};
-use zerocopy_derive::{AsBytes, FromBytes, FromZeroes};
+use zerocopy::{AsBytes, FromBytes, FromZeroes};
 use zvariant::Type;
 
 use super::{File, HashItemType};

--- a/gvdb/src/read/hash_item.rs
+++ b/gvdb/src/read/hash_item.rs
@@ -1,7 +1,7 @@
 use crate::read::error::{Error, Result};
 use crate::read::pointer::Pointer;
 use std::fmt::{Display, Formatter};
-use zerocopy_derive::{AsBytes, FromBytes, FromZeroes};
+use zerocopy::{AsBytes, FromBytes, FromZeroes};
 
 #[derive(PartialEq, Eq, Debug)]
 pub enum HashItemType {

--- a/gvdb/src/read/header.rs
+++ b/gvdb/src/read/header.rs
@@ -1,7 +1,6 @@
 use crate::read::error::{Error, Result};
 use crate::read::pointer::Pointer;
-use zerocopy::FromBytes;
-use zerocopy_derive::{AsBytes, FromBytes, FromZeroes};
+use zerocopy::{AsBytes, FromBytes, FromZeroes};
 
 // This is just a string, but it is stored in the byteorder of the file
 // Default byteorder is little endian, but the format supports big endian as well

--- a/gvdb/src/read/pointer.rs
+++ b/gvdb/src/read/pointer.rs
@@ -1,4 +1,4 @@
-use zerocopy_derive::{AsBytes, FromBytes, FromZeroes};
+use zerocopy::{AsBytes, FromBytes, FromZeroes};
 
 /// A pointer internal to the GVDB file.
 ///


### PR DESCRIPTION
The zerocopy derive feature is not purely additive. If another dependency has the feature in scope it will throw "the name `AsBytes` is defined multiple times" errors.