### PR TITLE
Fix GLib Variant backing data lifetimes

### DIFF
--- a/gvdb/src/read/hash.rs
+++ b/gvdb/src/read/hash.rs
@@ -385,7 +385,7 @@ impl<'table, 'file> HashTable<'table, 'file> {
     /// Returns the data for `key` as a [`struct@glib::Variant`].
     pub fn get_gvariant(&self, key: &str) -> Result<glib::Variant> {
         let data = self.get_bytes(key)?;
-        let variant = glib::Variant::from_data_with_type(data, glib::VariantTy::VARIANT);
+        let variant = glib::Variant::from_data_with_type(data.to_vec(), glib::VariantTy::VARIANT);
 
         if self.file.endianness == crate::Endian::native() {
             Ok(variant)

--- a/gvdb/src/test.rs
+++ b/gvdb/src/test.rs
@@ -103,8 +103,8 @@ fn write_byte_rows(
 
 pub fn assert_gvariant_eq(a: &[u8], b: &[u8], context: &str) {
     // Decode gvariant using glib, and diff using print()
-    let a_var = glib::Variant::from_data::<glib::Variant, _>(a);
-    let b_var = glib::Variant::from_data::<glib::Variant, _>(b);
+    let a_var = glib::Variant::from_data::<glib::Variant, _>(a.to_vec());
+    let b_var = glib::Variant::from_data::<glib::Variant, _>(b.to_vec());
 
     let a_str = a_var.print(true);
     let b_str = b_var.print(true);


### PR DESCRIPTION
GLib's Variant data constructors require their input buffer to remain valid throughout the Variant's lifetime. Convert borrowed byte slices to owned Vec buffers to satisfy this requirement.

This lifetime requirement was always necessary for correctness, but glib-rs 0.22.8 now expresses it in the Rust API so the compiler can enforce it.

Closes: https://github.com/felinira/gvdb-rs/issues/124