### PR TITLE
gresource: normalize relative directory paths on windows

### DIFF
--- a/gvdb/src/gresource/bundle.rs
+++ b/gvdb/src/gresource/bundle.rs
@@ -486,6 +486,11 @@ impl<'a> BundleBuilder<'a> {
                     }
                 };
 
+                // Normalize the separator of the relative path in order to avoid invalid keys
+                // like `com/example/App/assets\asset.svg`
+                #[cfg(target_os = "windows")]
+                let file_path_str_relative = file_path_str_relative.replace(std::path::MAIN_SEPARATOR, "/");
+
                 let options = if strip_blanks && file_path_str_relative.ends_with(".json") {
                     PreprocessOptions::json_stripblanks()
                 } else if strip_blanks && file_path_str_relative.ends_with(".xml")


### PR DESCRIPTION
Previously the underlying `OsStr` would contain backslash path separators on Windows, causing invalid GResource paths to be bundled in the final binary

Found this after trying to get [Fretboard](https://apps.gnome.org/Fretboard/) to compile for Windows with MSYS2/MSVC and spending hours thinking SVG rendering was broken lol